### PR TITLE
ci: use celestia-app from repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout Nova Repository
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,5 @@ jobs:
         with:
           go-version: "stable"
 
-      - name: Fetch Release
-        # download the celestia release for embedded tests.
-        run: curl -Lo appd/celestia-app_Linux_x86_64.tar.gz https://github.com/celestiaorg/celestia-app/releases/download/v3.3.1/celestia-app_Linux_x86_64.tar.gz
-
       - name: Run Tests
         run: make test-cover

--- a/passthrough.go
+++ b/passthrough.go
@@ -26,7 +26,7 @@ func NewPassthroughCmd(versions abci.Versions) (*cobra.Command, error) {
 		Long: `Execute a command on a specific app version.
 This allows interacting with older app versions for debugging or older queries.
 Use a version name to specify a named version or a height to execute on the version active at a specific height as first argument.`,
-		Example: `passsthrough v3 status`,
+		Example: `passthrough v3 status`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) >= 2 && strings.EqualFold("start", args[1]) {
 				return errors.New("cannot passthrough start command")


### PR DESCRIPTION
Small CI improvement to save bandwidth.
Eventually it celestia binaries will be removed, but that's a good in between solution.