### PR TITLE
chore: downgrade to go 1.23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ go.work.sum
 .servmon.yaml
 
 .idea
+vendor

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/01builders/nova
 
-go 1.24.0
+go 1.23.0
 
 require (
 	cosmossdk.io/log v1.5.0


### PR DESCRIPTION
To sort out the versioning issues in celestia-app we can downgrade for now.