### PR TITLE
chore: add short option for go test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,14 @@ jobs:
     steps:
       - name: Checkout Nova Repository
         uses: actions/checkout@v4
-        with:
-          lfs: true
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: "stable"
+
+      - name: Download v3 Celestia Binary
+        run: curl -L -o appd/internal/testdata/celestia-app_Linux_x86_64.tar.gz https://github.com/celestiaorg/celestia-app/releases/download/v3.4.0/celestia-app_Linux_x86_64.tar.gz
 
       - name: Run Tests
         run: make test-cover

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ GO ?= go
 test:
 	$(GO) test ./... -v
 
+test-short:
+	$(GO) test ./... -v -short
+
 # Run tests with coverage
 test-cover:
 	$(GO) test ./... -cover -v

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ test-cover:
 lint-fix:
 	golangci-lint run --fix
 
-.PHONY: test test-cover lint-fix
+.PHONY: test test-cover test-short lint-fix

--- a/appd/run_test.go
+++ b/appd/run_test.go
@@ -11,6 +11,10 @@ import (
 
 // TestCreateExecCommand execs a command to an embedded binary.
 func TestCreateExecCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test which expects an embedded binary")
+	}
+
 	bin, err := testdata.CelestiaApp()
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR adds a go test option with -short, this can be used to run tests which do not require local binaries to be embedded.

EDIT: noticed the same lfs error, also updated the workflow to download the binary again.