### PR TITLE
feat: support abci v1 & v2

### DIFF
--- a/abci/abci.go
+++ b/abci/abci.go
@@ -1,0 +1,8 @@
+package abci
+
+type ABCIClientVersion int
+
+const (
+	ABCIClientVersion1 ABCIClientVersion = iota
+	ABCIClientVersion2
+)

--- a/abci/multiplexer.go
+++ b/abci/multiplexer.go
@@ -181,7 +181,14 @@ func (m *Multiplexer) getAppForHeight(height int64) (servertypes.ABCI, error) {
 		}
 	}
 
-	return NewRemoteABCIClient(m.conn), nil
+	switch currentVersion.ABCIClientVersion {
+	case ABCIClientVersion1:
+		return NewRemoteABCIClientV1(m.conn), nil
+	case ABCIClientVersion2:
+		return NewRemoteABCIClientV2(m.conn), nil
+	}
+
+	return nil, fmt.Errorf("unknown ABCI client version %d", currentVersion.ABCIClientVersion)
 }
 
 // Cleanup allows proper multiplexer termination.

--- a/abci/multiplexer.go
+++ b/abci/multiplexer.go
@@ -70,10 +70,10 @@ func NewMultiplexer(
 	}
 
 	// prepare remote app client
-	const flagGRPCAddress = "grpc.address"
+	const flagGRPCAddress = "address"
 	grpcAddress := v.GetString(flagGRPCAddress)
 	if grpcAddress == "" {
-		grpcAddress = "localhost:9090"
+		grpcAddress = "localhost:26658"
 	}
 
 	conn, err := grpc.NewClient(
@@ -86,6 +86,10 @@ func NewMultiplexer(
 	wrapper.conn = conn
 
 	// start the correct version
+	if currentVersion.Appd == nil {
+		return nil, fmt.Errorf("appd is nil for height %d", currentHeight)
+	}
+
 	if currentVersion.Appd.Pid() == appd.AppdStopped {
 		programArgs := os.Args
 		if len(os.Args) > 2 {

--- a/abci/multiplexer.go
+++ b/abci/multiplexer.go
@@ -107,7 +107,7 @@ func NewMultiplexer(
 	// remove tcp:// prefix if present
 	tmAddress = strings.TrimPrefix(tmAddress, "tcp://")
 
-	conn, err := grpc.NewClient(
+	conn, err := grpc.Dial( //nolint:staticcheck: we want to check the connection.
 		tmAddress,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
@@ -258,11 +258,6 @@ func (m *Multiplexer) Info(_ context.Context, req *abci.RequestInfo) (*abci.Resp
 	app, err := m.getAppForHeight(m.lastHeight)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get app for height %d: %w", m.lastHeight, err)
-	}
-
-	// Add debug info about available services
-	if m.conn != nil {
-		fmt.Println("WENT HERE", req)
 	}
 
 	return app.Info(req)

--- a/abci/multiplexer.go
+++ b/abci/multiplexer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/spf13/viper"
@@ -70,14 +71,17 @@ func NewMultiplexer(
 	}
 
 	// prepare remote app client
-	const flagGRPCAddress = "address"
-	grpcAddress := v.GetString(flagGRPCAddress)
-	if grpcAddress == "" {
-		grpcAddress = "localhost:26658"
+	const flagTMAddress = "address"
+	tmAddress := v.GetString(flagTMAddress)
+	if tmAddress == "" {
+		tmAddress = "localhost:26658"
 	}
 
+	// remove tcp:// prefix if present
+	tmAddress = strings.TrimPrefix(tmAddress, "tcp://")
+
 	conn, err := grpc.NewClient(
-		grpcAddress,
+		tmAddress,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {

--- a/abci/remote.go
+++ b/abci/remote.go
@@ -13,7 +13,7 @@ type RemoteABCIClient struct {
 }
 
 // NewRemoteABCIClient returns a new ABCI Client.
-// This gRPC client connects to cometbft via grpc.
+// The client behaves like CometBFT for the server side (the application side).
 func NewRemoteABCIClient(conn *grpc.ClientConn) *RemoteABCIClient {
 	return &RemoteABCIClient{ABCIClient: abci.NewABCIClient(conn)}
 }

--- a/abci/remote_v1.go
+++ b/abci/remote_v1.go
@@ -1,0 +1,459 @@
+package abci
+
+import (
+	"context"
+	"math"
+
+	"google.golang.org/grpc"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	abciv2 "github.com/cometbft/cometbft/abci/types"
+	cryptov2 "github.com/cometbft/cometbft/proto/tendermint/crypto"
+	typesv2 "github.com/cometbft/cometbft/proto/tendermint/types"
+	abciv1 "github.com/tendermint/tendermint/abci/types"
+	cryptov1 "github.com/tendermint/tendermint/proto/tendermint/crypto"
+	typesv1 "github.com/tendermint/tendermint/proto/tendermint/types"
+	versionv1 "github.com/tendermint/tendermint/proto/tendermint/version"
+)
+
+type RemoteABCIClientV1 struct {
+	abciv1.ABCIApplicationClient
+}
+
+// NewRemoteABCIClientV1 returns a new ABCI Client (using ABCI v1).
+// The client behaves like Tendermint for the server side (the application side).
+func NewRemoteABCIClientV1(conn *grpc.ClientConn) *RemoteABCIClientV1 {
+	return &RemoteABCIClientV1{
+		ABCIApplicationClient: abciv1.NewABCIApplicationClient(conn),
+	}
+}
+
+// ApplySnapshotChunk implements abciv2.ABCI
+func (a *RemoteABCIClientV1) ApplySnapshotChunk(req *abciv2.RequestApplySnapshotChunk) (*abciv2.ResponseApplySnapshotChunk, error) {
+	resp, err := a.ABCIApplicationClient.ApplySnapshotChunk(
+		context.Background(),
+		&abciv1.RequestApplySnapshotChunk{
+			Index:  req.Index,
+			Chunk:  req.Chunk,
+			Sender: req.Sender,
+		},
+		grpc.WaitForReady(true),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &abciv2.ResponseApplySnapshotChunk{
+		Result:        abci.ResponseApplySnapshotChunk_Result(resp.Result),
+		RefetchChunks: resp.RefetchChunks,
+		RejectSenders: resp.RejectSenders,
+	}, nil
+}
+
+// CheckTx implements abciv2.ABCI
+func (a *RemoteABCIClientV1) CheckTx(req *abciv2.RequestCheckTx) (*abciv2.ResponseCheckTx, error) {
+	resp, err := a.ABCIApplicationClient.CheckTx(context.Background(), &abciv1.RequestCheckTx{
+		Tx:   req.Tx,
+		Type: abciv1.CheckTxType(req.Type),
+	}, grpc.WaitForReady(true))
+	if err != nil {
+		return nil, err
+	}
+
+	return &abciv2.ResponseCheckTx{
+		Code:      resp.Code,
+		Data:      resp.Data,
+		Log:       resp.Log,
+		Info:      resp.Info,
+		GasWanted: resp.GasWanted,
+		GasUsed:   resp.GasUsed,
+		Events:    abciEventV1ToV2(resp.Events...),
+		Codespace: resp.Codespace,
+	}, nil
+}
+
+// Commit implements abciv2.ABCI
+func (a *RemoteABCIClientV1) Commit() (*abciv2.ResponseCommit, error) {
+	resp, err := a.ABCIApplicationClient.Commit(context.Background(), &abciv1.RequestCommit{}, grpc.WaitForReady(true))
+	if err != nil {
+		return nil, err
+	}
+
+	return &abciv2.ResponseCommit{
+		// Data:         resp.Data, // TODO: there no data here.
+		RetainHeight: resp.RetainHeight,
+	}, nil
+}
+
+// FinalizeBlock implements abciv2.ABCI
+func (a *RemoteABCIClientV1) FinalizeBlock(req *abciv2.RequestFinalizeBlock) (*abciv2.ResponseFinalizeBlock, error) {
+	beginBlockResp, err := a.ABCIApplicationClient.BeginBlock(context.Background(), &abciv1.RequestBeginBlock{
+		Hash:                req.Hash,
+		Header:              typesv1.Header{},
+		LastCommitInfo:      abciv1.LastCommitInfo{},
+		ByzantineValidators: []abciv1.Evidence{},
+	}, grpc.WaitForReady(true))
+	if err != nil {
+		return nil, err
+	}
+
+	commitBlockResps := make([]*abciv1.ResponseDeliverTx, 0, len(req.Txs))
+	for _, tx := range req.Txs {
+		commitBlockResp, err := a.ABCIApplicationClient.DeliverTx(context.Background(), &abciv1.RequestDeliverTx{
+			Tx: tx,
+		}, grpc.WaitForReady(true))
+		if err != nil {
+			return nil, err
+		}
+
+		commitBlockResps = append(commitBlockResps, commitBlockResp)
+	}
+
+	endBlockResp, err := a.ABCIApplicationClient.EndBlock(
+		context.Background(),
+		&abciv1.RequestEndBlock{
+			Height: req.Height,
+		},
+		grpc.WaitForReady(true),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// convert events
+	var events []abciv2.Event
+	events = append(events, abciEventV1ToV2(beginBlockResp.Events...)...)
+	for _, commitBlockResp := range commitBlockResps {
+		events = append(events, abciEventV1ToV2(commitBlockResp.Events...)...)
+	}
+	events = append(events, abciEventV1ToV2(endBlockResp.Events...)...)
+
+	return &abciv2.ResponseFinalizeBlock{
+		Events:                events,
+		TxResults:             nil,
+		ValidatorUpdates:      validatorUpdatesV1ToV2(endBlockResp.ValidatorUpdates),
+		ConsensusParamUpdates: nil,
+		AppHash:               nil,
+	}, nil
+}
+
+// Info implements abciv2.ABCI
+func (a *RemoteABCIClientV1) Info(req *abciv2.RequestInfo) (*abciv2.ResponseInfo, error) {
+	resp, err := a.ABCIApplicationClient.Info(context.Background(), &abciv1.RequestInfo{
+		Version:      req.Version,
+		BlockVersion: req.BlockVersion,
+		P2PVersion:   req.P2PVersion,
+	}, grpc.WaitForReady(true))
+	if err != nil {
+		return nil, err
+	}
+
+	return &abciv2.ResponseInfo{
+		Data:             resp.Data,
+		Version:          resp.Version,
+		AppVersion:       resp.AppVersion,
+		LastBlockHeight:  resp.LastBlockHeight,
+		LastBlockAppHash: resp.LastBlockAppHash,
+	}, nil
+}
+
+// InitChain implements abciv2.ABCI
+func (a *RemoteABCIClientV1) InitChain(req *abciv2.RequestInitChain) (*abciv2.ResponseInitChain, error) {
+	consensusParamsV1 := &abciv1.ConsensusParams{ // TODO nil checks
+		Block: &abciv1.BlockParams{
+			MaxBytes: req.ConsensusParams.Block.MaxBytes,
+			MaxGas:   req.ConsensusParams.Block.MaxGas,
+		},
+		Evidence: &typesv1.EvidenceParams{
+			MaxAgeNumBlocks: req.ConsensusParams.Evidence.MaxAgeNumBlocks,
+			MaxAgeDuration:  req.ConsensusParams.Evidence.MaxAgeDuration,
+		},
+		Version: &typesv1.VersionParams{
+			AppVersion: req.ConsensusParams.Version.App,
+		},
+	}
+
+	resp, err := a.ABCIApplicationClient.InitChain(context.Background(), &abciv1.RequestInitChain{
+		Time:            req.Time,
+		ChainId:         req.ChainId,
+		ConsensusParams: consensusParamsV1,
+		Validators:      validatorUpdatesV2ToV1(req.Validators),
+		AppStateBytes:   req.AppStateBytes,
+		InitialHeight:   req.InitialHeight,
+	}, grpc.WaitForReady(true))
+	if err != nil {
+		return nil, err
+	}
+
+	consensusParamsV2 := &typesv2.ConsensusParams{
+		Block: &typesv2.BlockParams{
+			MaxBytes: resp.ConsensusParams.Block.MaxBytes,
+			MaxGas:   resp.ConsensusParams.Block.MaxGas,
+		},
+		Evidence: &typesv2.EvidenceParams{
+			MaxAgeNumBlocks: resp.ConsensusParams.Evidence.MaxAgeNumBlocks,
+			MaxAgeDuration:  resp.ConsensusParams.Evidence.MaxAgeDuration,
+		},
+		Version: &typesv2.VersionParams{
+			App: resp.ConsensusParams.Version.AppVersion,
+		},
+	}
+
+	return &abciv2.ResponseInitChain{
+		ConsensusParams: consensusParamsV2,
+		Validators:      validatorUpdatesV1ToV2(resp.Validators),
+		AppHash:         resp.AppHash,
+	}, nil
+}
+
+// ListSnapshots implements abciv2.ABCI
+func (a *RemoteABCIClientV1) ListSnapshots(req *abciv2.RequestListSnapshots) (*abciv2.ResponseListSnapshots, error) {
+	resp, err := a.ABCIApplicationClient.ListSnapshots(
+		context.Background(),
+		&abciv1.RequestListSnapshots{},
+		grpc.WaitForReady(true),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshots := make([]*abciv2.Snapshot, 0, len(resp.Snapshots))
+	for _, snapshot := range resp.Snapshots {
+		snapshots = append(snapshots, &abciv2.Snapshot{
+			Height: snapshot.Height,
+			Format: snapshot.Format,
+			Chunks: snapshot.Chunks,
+			Hash:   snapshot.Hash,
+		})
+	}
+
+	return &abciv2.ResponseListSnapshots{
+		Snapshots: snapshots,
+	}, nil
+}
+
+// LoadSnapshotChunk implements abciv2.ABCI
+func (a *RemoteABCIClientV1) LoadSnapshotChunk(req *abciv2.RequestLoadSnapshotChunk) (*abci.ResponseLoadSnapshotChunk, error) {
+	resp, err := a.ABCIApplicationClient.LoadSnapshotChunk(
+		context.Background(),
+		&abciv1.RequestLoadSnapshotChunk{
+			Height: req.Height,
+			Format: req.Chunk,
+			Chunk:  req.Chunk,
+		},
+		grpc.WaitForReady(true),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &abci.ResponseLoadSnapshotChunk{
+		Chunk: resp.GetChunk(),
+	}, nil
+}
+
+// OfferSnapshot implements abciv2.ABCI
+func (a *RemoteABCIClientV1) OfferSnapshot(req *abciv2.RequestOfferSnapshot) (*abciv2.ResponseOfferSnapshot, error) {
+	resp, err := a.ABCIApplicationClient.OfferSnapshot(
+		context.Background(),
+		&abciv1.RequestOfferSnapshot{
+			Snapshot: &abciv1.Snapshot{
+				Height:   req.Snapshot.Height,
+				Format:   req.Snapshot.Format,
+				Chunks:   req.Snapshot.Chunks,
+				Hash:     req.Snapshot.Hash,
+				Metadata: req.Snapshot.Metadata,
+			},
+			AppHash:    req.AppHash,
+			AppVersion: 3, // TODO: hardcoded as not available in v0.38 fork
+		},
+		grpc.WaitForReady(true),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &abciv2.ResponseOfferSnapshot{
+		Result: abci.ResponseOfferSnapshot_Result(resp.Result),
+	}, nil
+}
+
+// PrepareProposal implements abciv2.ABCI
+func (a *RemoteABCIClientV1) PrepareProposal(req *abciv2.RequestPrepareProposal) (*abciv2.ResponsePrepareProposal, error) {
+	resp, err := a.ABCIApplicationClient.PrepareProposal(context.Background(), &abciv1.RequestPrepareProposal{
+		BlockData: &typesv1.Data{
+			Txs:        req.Txs,
+			SquareSize: 0, // TODO: hardcoded as not available in v0.38 fork
+		},
+		BlockDataSize: math.MaxInt32, // TODO: hardcoded as not available in v0.38 fork
+		ChainId:       "",            // TODO: hardcoded as not available in v0.38 fork
+		Height:        req.Height,
+		Time:          req.Time,
+	},
+		grpc.WaitForReady(true))
+	if err != nil {
+		return nil, err
+	}
+
+	return &abciv2.ResponsePrepareProposal{
+		Txs: resp.BlockData.Txs,
+	}, nil
+}
+
+// ProcessProposal implements abciv2.ABCI
+func (a *RemoteABCIClientV1) ProcessProposal(req *abciv2.RequestProcessProposal) (*abciv2.ResponseProcessProposal, error) {
+	resp, err := a.ABCIApplicationClient.ProcessProposal(context.Background(), &abciv1.RequestProcessProposal{
+		Header: typesv1.Header{
+			Version: versionv1.Consensus{
+				Block: 0, // TODO: hardcoded as not available in v0.38 fork
+				App:   0, // TODO: hardcoded as not available in v0.38 fork
+			},
+			ChainID:            "", // TODO: hardcoded as not available in v0.38 fork
+			Height:             req.Height,
+			Time:               req.Time,
+			NextValidatorsHash: req.NextValidatorsHash,
+			ProposerAddress:    req.ProposerAddress,
+		},
+		BlockData: &typesv1.Data{
+			Txs:        req.Txs,
+			SquareSize: 0, // TODO: hardcoded as not available in v0.38 fork
+			Hash:       req.Hash,
+		},
+	},
+		grpc.WaitForReady(true))
+	if err != nil {
+		return nil, err
+	}
+
+	return &abciv2.ResponseProcessProposal{
+		Status: abciv2.ResponseProcessProposal_ProposalStatus(resp.Result),
+	}, nil
+
+}
+
+// Query implements abciv2.ABCI
+func (a *RemoteABCIClientV1) Query(ctx context.Context, req *abciv2.RequestQuery) (*abciv2.ResponseQuery, error) {
+	resp, err := a.ABCIApplicationClient.Query(ctx, &abciv1.RequestQuery{
+		Data:   req.Data,
+		Path:   req.Path,
+		Height: req.Height,
+		Prove:  req.Prove,
+	}, grpc.WaitForReady(true))
+	if err != nil {
+		return nil, err
+	}
+
+	proofOps := &cryptov2.ProofOps{}
+	if resp.ProofOps != nil && len(resp.ProofOps.Ops) > 0 {
+		proofOps.Ops = make([]cryptov2.ProofOp, 0, len(resp.ProofOps.Ops))
+		for _, proofOp := range resp.ProofOps.Ops {
+			proofOps.Ops = append(proofOps.Ops, cryptov2.ProofOp{
+				Type: proofOp.Type,
+				Key:  proofOp.Key,
+				Data: proofOp.Data,
+			})
+		}
+	}
+
+	return &abciv2.ResponseQuery{
+		Code:      resp.Code,
+		Log:       resp.Log,
+		Info:      resp.Info,
+		Value:     resp.Value,
+		Index:     resp.Index,
+		Key:       resp.Key,
+		ProofOps:  proofOps,
+		Height:    resp.Height,
+		Codespace: resp.Codespace,
+	}, nil
+}
+
+// VerifyVoteExtension implements abciv2.ABCI
+func (a *RemoteABCIClientV1) VerifyVoteExtension(req *abciv2.RequestVerifyVoteExtension) (*abciv2.ResponseVerifyVoteExtension, error) {
+	return &abciv2.ResponseVerifyVoteExtension{}, nil
+}
+
+// ExtendVote implements abciv2.ABCI
+func (a *RemoteABCIClientV1) ExtendVote(ctx context.Context, req *abciv2.RequestExtendVote) (*abciv2.ResponseExtendVote, error) {
+	return &abciv2.ResponseExtendVote{}, nil
+}
+
+// abciEventV1ToV2 converts a slice of abciv1.Event to a slice of abciv2.Event.
+func abciEventV1ToV2(events ...abciv1.Event) []abciv2.Event {
+	v2Events := make([]abciv2.Event, 0, len(events))
+
+	for _, event := range events {
+		attributes := make([]abciv2.EventAttribute, 0, len(event.Attributes))
+		for _, attr := range event.Attributes {
+			attributes = append(attributes, abciv2.EventAttribute{
+				Key:   string(attr.Key),
+				Value: string(attr.Value),
+			})
+		}
+
+		v2Events = append(v2Events, abciv2.Event{
+			Type:       event.Type,
+			Attributes: attributes,
+		})
+	}
+
+	return v2Events
+}
+
+func validatorUpdatesV1ToV2(validators []abciv1.ValidatorUpdate) []abciv2.ValidatorUpdate {
+	v2Updates := make([]abciv2.ValidatorUpdate, len(validators))
+	for i, validator := range validators {
+		var pubKeyV2 cryptov2.PublicKey
+		if pubKey := validator.GetPubKey(); pubKey.GetEd25519() != nil {
+			pubKeyV2 = cryptov2.PublicKey{
+				Sum: &cryptov2.PublicKey_Ed25519{
+					Ed25519: pubKey.GetEd25519(),
+				},
+			}
+		} else if pubKey := validator.GetPubKey(); pubKey.GetSecp256K1() != nil {
+			pubKeyV2 = cryptov2.PublicKey{
+				Sum: &cryptov2.PublicKey_Secp256K1{
+					Secp256K1: pubKey.GetSecp256K1(),
+				},
+			}
+		} else {
+			continue
+		}
+
+		v2Updates[i] = abciv2.ValidatorUpdate{
+			PubKey: pubKeyV2,
+			Power:  validator.Power,
+		}
+	}
+
+	return v2Updates
+}
+
+func validatorUpdatesV2ToV1(validators []abciv2.ValidatorUpdate) []abciv1.ValidatorUpdate {
+	v1Updates := make([]abciv1.ValidatorUpdate, len(validators))
+	for i, validator := range validators {
+		var pubKeyV1 cryptov1.PublicKey
+		if pubKey := validator.GetPubKey(); pubKey.GetEd25519() != nil {
+			pubKeyV1 = cryptov1.PublicKey{
+				Sum: &cryptov1.PublicKey_Ed25519{
+					Ed25519: pubKey.GetEd25519(),
+				},
+			}
+		} else if pubKey := validator.GetPubKey(); pubKey.GetSecp256K1() != nil {
+			pubKeyV1 = cryptov1.PublicKey{
+				Sum: &cryptov1.PublicKey_Secp256K1{
+					Secp256K1: pubKey.GetSecp256K1(),
+				},
+			}
+		} else {
+			continue
+		}
+
+		v1Updates[i] = abciv1.ValidatorUpdate{
+			PubKey: pubKeyV1,
+			Power:  validator.Power,
+		}
+	}
+
+	return v1Updates
+}

--- a/abci/remote_v2.go
+++ b/abci/remote_v2.go
@@ -8,83 +8,83 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 )
 
-type RemoteABCIClient struct {
+type RemoteABCIClientV2 struct {
 	abci.ABCIClient
 }
 
-// NewRemoteABCIClient returns a new ABCI Client.
+// NewRemoteABCIClientV2 returns a new ABCI Client (using ABCI v2).
 // The client behaves like CometBFT for the server side (the application side).
-func NewRemoteABCIClient(conn *grpc.ClientConn) *RemoteABCIClient {
-	return &RemoteABCIClient{ABCIClient: abci.NewABCIClient(conn)}
+func NewRemoteABCIClientV2(conn *grpc.ClientConn) *RemoteABCIClientV2 {
+	return &RemoteABCIClientV2{ABCIClient: abci.NewABCIClient(conn)}
 }
 
 // ApplySnapshotChunk implements abci.ABCI.
-func (a *RemoteABCIClient) ApplySnapshotChunk(req *abci.RequestApplySnapshotChunk) (*abci.ResponseApplySnapshotChunk, error) {
+func (a *RemoteABCIClientV2) ApplySnapshotChunk(req *abci.RequestApplySnapshotChunk) (*abci.ResponseApplySnapshotChunk, error) {
 	return a.ABCIClient.ApplySnapshotChunk(context.Background(), req, grpc.WaitForReady(true))
 }
 
 // CheckTx implements abci.ABCI.
-func (a *RemoteABCIClient) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error) {
+func (a *RemoteABCIClientV2) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error) {
 	return a.ABCIClient.CheckTx(context.Background(), req, grpc.WaitForReady(true))
 }
 
 // Commit implements abci.ABCI.
-func (a *RemoteABCIClient) Commit() (*abci.ResponseCommit, error) {
+func (a *RemoteABCIClientV2) Commit() (*abci.ResponseCommit, error) {
 	return a.ABCIClient.Commit(context.Background(), &abci.RequestCommit{}, grpc.WaitForReady(true))
 }
 
 // ExtendVote implements abci.ABCI.
-func (a *RemoteABCIClient) ExtendVote(ctx context.Context, req *abci.RequestExtendVote) (*abci.ResponseExtendVote, error) {
+func (a *RemoteABCIClientV2) ExtendVote(ctx context.Context, req *abci.RequestExtendVote) (*abci.ResponseExtendVote, error) {
 	return a.ABCIClient.ExtendVote(ctx, req, grpc.WaitForReady(true))
 }
 
 // FinalizeBlock implements abci.ABCI.
-func (a *RemoteABCIClient) FinalizeBlock(req *abci.RequestFinalizeBlock) (*abci.ResponseFinalizeBlock, error) {
+func (a *RemoteABCIClientV2) FinalizeBlock(req *abci.RequestFinalizeBlock) (*abci.ResponseFinalizeBlock, error) {
 	return a.ABCIClient.FinalizeBlock(context.Background(), req, grpc.WaitForReady(true))
 }
 
 // Info implements abci.ABCI.
-func (a *RemoteABCIClient) Info(req *abci.RequestInfo) (*abci.ResponseInfo, error) {
+func (a *RemoteABCIClientV2) Info(req *abci.RequestInfo) (*abci.ResponseInfo, error) {
 	return a.ABCIClient.Info(context.Background(), req, grpc.WaitForReady(true))
 }
 
 // InitChain implements abci.ABCI.
-func (a *RemoteABCIClient) InitChain(req *abci.RequestInitChain) (*abci.ResponseInitChain, error) {
+func (a *RemoteABCIClientV2) InitChain(req *abci.RequestInitChain) (*abci.ResponseInitChain, error) {
 	return a.ABCIClient.InitChain(context.Background(), req, grpc.WaitForReady(true))
 }
 
 // ListSnapshots implements abci.ABCI.
-func (a *RemoteABCIClient) ListSnapshots(req *abci.RequestListSnapshots) (*abci.ResponseListSnapshots, error) {
+func (a *RemoteABCIClientV2) ListSnapshots(req *abci.RequestListSnapshots) (*abci.ResponseListSnapshots, error) {
 	return a.ABCIClient.ListSnapshots(context.Background(), req, grpc.WaitForReady(true))
 }
 
 // LoadSnapshotChunk implements abci.ABCI.
-func (a *RemoteABCIClient) LoadSnapshotChunk(req *abci.RequestLoadSnapshotChunk) (*abci.ResponseLoadSnapshotChunk, error) {
+func (a *RemoteABCIClientV2) LoadSnapshotChunk(req *abci.RequestLoadSnapshotChunk) (*abci.ResponseLoadSnapshotChunk, error) {
 	return a.ABCIClient.LoadSnapshotChunk(context.Background(), req, grpc.WaitForReady(true))
 }
 
 // OfferSnapshot implements abci.ABCI.
-func (a *RemoteABCIClient) OfferSnapshot(req *abci.RequestOfferSnapshot) (*abci.ResponseOfferSnapshot, error) {
+func (a *RemoteABCIClientV2) OfferSnapshot(req *abci.RequestOfferSnapshot) (*abci.ResponseOfferSnapshot, error) {
 	return a.ABCIClient.OfferSnapshot(context.Background(), req, grpc.WaitForReady(true))
 }
 
 // PrepareProposal implements abci.ABCI.
-func (a *RemoteABCIClient) PrepareProposal(req *abci.RequestPrepareProposal) (*abci.ResponsePrepareProposal, error) {
+func (a *RemoteABCIClientV2) PrepareProposal(req *abci.RequestPrepareProposal) (*abci.ResponsePrepareProposal, error) {
 	return a.ABCIClient.PrepareProposal(context.Background(), req, grpc.WaitForReady(true))
 }
 
 // ProcessProposal implements abci.ABCI.
-func (a *RemoteABCIClient) ProcessProposal(req *abci.RequestProcessProposal) (*abci.ResponseProcessProposal, error) {
+func (a *RemoteABCIClientV2) ProcessProposal(req *abci.RequestProcessProposal) (*abci.ResponseProcessProposal, error) {
 	return a.ABCIClient.ProcessProposal(context.Background(), req, grpc.WaitForReady(true))
 }
 
 // Query implements abci.ABCI.
-func (a *RemoteABCIClient) Query(ctx context.Context, req *abci.RequestQuery) (*abci.ResponseQuery, error) {
+func (a *RemoteABCIClientV2) Query(ctx context.Context, req *abci.RequestQuery) (*abci.ResponseQuery, error) {
 	return a.ABCIClient.Query(ctx, req, grpc.WaitForReady(true))
 }
 
 // VerifyVoteExtension implements abci.ABCI.
-func (a *RemoteABCIClient) VerifyVoteExtension(req *abci.RequestVerifyVoteExtension) (*abci.ResponseVerifyVoteExtension, error) {
+func (a *RemoteABCIClientV2) VerifyVoteExtension(req *abci.RequestVerifyVoteExtension) (*abci.ResponseVerifyVoteExtension, error) {
 	return a.ABCIClient.VerifyVoteExtension(context.Background(), req, grpc.WaitForReady(true))
 
 }

--- a/abci/versions.go
+++ b/abci/versions.go
@@ -103,7 +103,7 @@ func (v Version) GetStartArgs(args []string) []string {
 	// Default flags for standalone apps.
 	return append(args,
 		"--grpc.enable=true",
-		"--api.enable=false",
+		"--api.enable=true",
 		"--api.swagger=false",
 		"--with-tendermint=false",
 		"--transport=grpc",

--- a/abci/versions.go
+++ b/abci/versions.go
@@ -106,7 +106,7 @@ func (v Version) GetStartArgs(args []string) []string {
 		"--api.enable=true",
 		"--api.swagger=false",
 		"--with-tendermint=false",
-		"--transport=socket",
+		"--transport=grpc",
 	)
 }
 

--- a/abci/versions.go
+++ b/abci/versions.go
@@ -106,7 +106,7 @@ func (v Version) GetStartArgs(args []string) []string {
 		"--api.enable=true",
 		"--api.swagger=false",
 		"--with-tendermint=false",
-		"--transport=grpc",
+		"--transport=socket",
 	)
 }
 

--- a/abci/versions.go
+++ b/abci/versions.go
@@ -13,11 +13,12 @@ var ErrNoVersionFound = errors.New("no version found")
 
 // Version defines the configuration for remote apps.
 type Version struct {
-	Name        string
-	Appd        *appd.Appd
-	UntilHeight int64
-	PreHandler  string   // Command to run before starting the app
-	StartArgs   []string // Extra arguments to pass to the app
+	Name              string
+	ABCIClientVersion ABCIClientVersion
+	Appd              *appd.Appd
+	UntilHeight       int64
+	PreHandler        string   // Command to run before starting the app
+	StartArgs         []string // Extra arguments to pass to the app
 }
 
 type Versions []Version

--- a/abci/versions.go
+++ b/abci/versions.go
@@ -3,8 +3,9 @@ package abci
 import (
 	"errors"
 	"fmt"
-	"github.com/01builders/nova/appd"
 	"sort"
+
+	"github.com/01builders/nova/appd"
 )
 
 // ErrNoVersionFound is returned when no remote version is found for a given height.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,10 @@
 module github.com/01builders/nova
 
-go 1.23.0
+go 1.23.1
+
+toolchain go1.24.1
+
+replace github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.45.0-tm-v0.34.35
 
 require (
 	cosmossdk.io/log v1.5.0
@@ -12,6 +16,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
+	github.com/tendermint/tendermint v0.0.0-00010101000000-000000000000
 	golang.org/x/sync v0.12.0
 	google.golang.org/grpc v1.71.0
 )
@@ -103,23 +108,23 @@ require (
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/lib/pq v1.10.7 // indirect
+	github.com/lib/pq v1.10.9 // indirect
 	github.com/linxGnu/grocksdb v1.8.14 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/minio/highwayhash v1.0.2 // indirect
+	github.com/minio/highwayhash v1.0.3 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20230904125328-1f23a7beb09a // indirect
 	github.com/oklog/run v1.1.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/petermattis/goid v0.0.0-20231207134359-e60b3f734c67 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.20.1 // indirect
+	github.com/prometheus/client_golang v1.20.3 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
@@ -145,7 +150,7 @@ require (
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0 // indirect
+	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/term v0.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4
 github.com/bytedance/sonic/loader v0.2.0 h1:zNprn+lsIP06C/IqCHs3gPQIvnvpKbbxyXQP1iU4kWM=
 github.com/bytedance/sonic/loader v0.2.0/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
+github.com/celestiaorg/celestia-core v1.45.0-tm-v0.34.35 h1:T21AhezjcByAlWDHmiVbpg743Uqk/dqBzJkQsAnbQf8=
+github.com/celestiaorg/celestia-core v1.45.0-tm-v0.34.35/go.mod h1:fQ46s1hYFTGFBsHsuGsbxDZ720ZPQow5Iyqw+yErZSo=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -480,8 +482,8 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
-github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
-github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linxGnu/grocksdb v1.8.14 h1:HTgyYalNwBSG/1qCQUIott44wU5b2Y9Kr3z7SK5OfGQ=
@@ -508,8 +510,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
-github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
+github.com/minio/highwayhash v1.0.3 h1:kbnuUMoHYyVl7szWjSxJnxw11k2U709jqFPPmIUyD6Q=
+github.com/minio/highwayhash v1.0.3/go.mod h1:GGYsuwP/fPD6Y9hMiXuapVvlIUEhFhMTh0rxU3ik1LQ=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -567,8 +569,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/onsi/gomega v1.26.0 h1:03cDLK28U6hWvCAns6NeydX3zIm4SF3ci69ulidS32Q=
-github.com/onsi/gomega v1.26.0/go.mod h1:r+zV744Re+DiYCIPRlYOTxn0YkOLcAnW8k1xXdMPGhM=
+github.com/onsi/gomega v1.34.2 h1:pNCwDkzrsv7MS9kpaQvVb1aVLahQXyJ/Tv5oAZMI3i8=
+github.com/onsi/gomega v1.34.2/go.mod h1:v1xfxRgk0KIsG+QOdm7p8UosrOzPYRo60fd3B/1Dukc=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
@@ -592,8 +594,8 @@ github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0Mw
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
-github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
-github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
+github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
+github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
 github.com/petermattis/goid v0.0.0-20231207134359-e60b3f734c67 h1:jik8PHtAIsPlCRJjJzl4udgEf7hawInF9texMeO2jrU=
@@ -619,8 +621,8 @@ github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeD
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
-github.com/prometheus/client_golang v1.20.1 h1:IMJXHOD6eARkQpxo8KkhgEVFlBNm+nkrFUyGlIu7Na8=
-github.com/prometheus/client_golang v1.20.1/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
+github.com/prometheus/client_golang v1.20.3 h1:oPksm4K8B+Vt35tUhw6GbSNSgVlVSBH0qELP/7u83l4=
+github.com/prometheus/client_golang v1.20.3/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -679,8 +681,8 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
-github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -728,8 +730,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
@@ -810,8 +810,8 @@ golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ug
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
-golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0 h1:985EYyeCOxTpcgOTJpflJUwOeEz0CQOdPt73OzpE9F8=
-golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0/go.mod h1:/lliqkxwWAhPjf5oSOIJup2XcqJaw8RGS6k3TGEc7GI=
+golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e h1:I88y4caeGeuDQxgdoFPUq097j7kNfw6uvuiNxUBfcBk=
+golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -825,8 +825,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
-golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
+golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -878,7 +878,6 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190130150945-aca44879d564/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -926,6 +925,7 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -962,8 +962,8 @@ golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
-golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
+golang.org/x/tools v0.24.0 h1:J1shsA93PJUEVaUSaay7UXAyE8aimq3GW0pjlolpa24=
+golang.org/x/tools v0.24.0/go.mod h1:YhNqVBIfWHdzvTLs0d8LCuMhkKUgSUKldakyV7W/WDQ=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/start.go
+++ b/start.go
@@ -12,12 +12,10 @@ import (
 	"cosmossdk.io/log"
 	"cosmossdk.io/store/rootmulti"
 	"github.com/01builders/nova/abci"
-	cmtabci "github.com/cometbft/cometbft/abci/types"
 	cmtcfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/node"
 	"github.com/cometbft/cometbft/p2p"
 	pvm "github.com/cometbft/cometbft/privval"
-	"github.com/cometbft/cometbft/proxy"
 	"github.com/cometbft/cometbft/rpc/client/local"
 	cmttypes "github.com/cometbft/cometbft/types"
 	dbm "github.com/cosmos/cosmos-db"
@@ -54,9 +52,14 @@ func New(versions abci.Versions) StartCommandHandler {
 		svrCtx *server.Context,
 		clientCtx client.Context,
 		appCreator types.AppCreator,
-		_ bool,
+		withCmt bool,
 		_ server.StartCmdOptions,
 	) error {
+		if !withCmt {
+			svrCtx.Logger.Info("App cannot be started without CometBFT when using the multiplexer.")
+			return nil
+		}
+
 		return start(versions, svrCtx, clientCtx, appCreator)
 	}
 }
@@ -131,8 +134,14 @@ func startInProcess(
 		svrCtx.Logger.Info("starting node in gRPC only mode; CometBFT is disabled")
 		svrCfg.GRPC.Enable = true
 	} else {
-		svrCtx.Logger.Info("starting node with ABCI CometBFT in-process")
-		tmNode, cleanupFn, err := startCmtNode(versions, currentHeight, ctx, cmtCfg, app, svrCtx)
+		if !isLatestApp {
+			svrCtx.Logger.Info("starting node with multiplexer")
+		} else {
+			svrCtx.Logger.Info("starting node with latest app")
+		}
+		tmNode, cleanupFn, err := startCmtNode(
+			versions, currentHeight, ctx, cmtCfg, app, svrCtx, isLatestApp,
+		)
 		if err != nil {
 			return err
 		}
@@ -178,13 +187,14 @@ func startCmtNode(
 	cfg *cmtcfg.Config,
 	app types.Application,
 	svrCtx *server.Context,
+	isLatestApp bool,
 ) (tmNode *node.Node, cleanupFn func(), err error) {
 	nodeKey, err := p2p.LoadOrGenNodeKey(cfg.NodeKeyFile())
 	if err != nil {
 		return nil, cleanupFn, err
 	}
 
-	cmtApp, err := abci.NewMultiplexer(
+	clientCreator, multiplexerCleanup, err := abci.NewMultiplexer(
 		svrCtx.Logger.With("multiplexer"),
 		svrCtx.Viper,
 		app,
@@ -195,16 +205,16 @@ func startCmtNode(
 		return nil, cleanupFn, err
 	}
 
-	// Register cleanup handler for remote apps
-	setupRemoteAppCleanup(cmtApp, svrCtx)
-
+	if !isLatestApp {
+		// Register cleanup handler for remote apps
+		setupRemoteAppCleanup(svrCtx, multiplexerCleanup)
+	}
 	tmNode, err = node.NewNodeWithContext(
 		ctx,
 		cfg,
 		pvm.LoadOrGenFilePV(cfg.PrivValidatorKeyFile(), cfg.PrivValidatorStateFile()),
 		nodeKey,
-		// we use local client creator because the latest app shouldn't use grpc
-		proxy.NewLocalClientCreator(cmtApp),
+		clientCreator,
 		getGenDocProvider(cfg),
 		cmtcfg.DefaultDBProvider,
 		node.DefaultMetricsProvider(cfg.Instrumentation),
@@ -223,36 +233,31 @@ func startCmtNode(
 			_ = tmNode.Stop()
 		}
 
-		// also ensure we stop any remote apps
-		if multiplexer, ok := cmtApp.(*abci.Multiplexer); ok {
-			_ = multiplexer.Cleanup()
-		}
+		_ = multiplexerCleanup()
 	}
 
 	return tmNode, cleanupFn, nil
 }
 
 // setupRemoteAppCleanup ensures that remote app processes are terminated when the main process receives termination signals
-func setupRemoteAppCleanup(cmtApp cmtabci.Application, svrCtx *server.Context) {
-	if multiplexer, ok := cmtApp.(*abci.Multiplexer); ok {
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+func setupRemoteAppCleanup(svrCtx *server.Context, cleanupFn func() error) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 
-		go func() {
-			sig := <-sigCh
-			svrCtx.Logger.Info("Received signal, stopping remote apps...", "signal", sig)
+	go func() {
+		sig := <-sigCh
+		svrCtx.Logger.Info("Received signal, stopping remote apps...", "signal", sig)
 
-			if err := multiplexer.Cleanup(); err != nil {
-				svrCtx.Logger.Error("Error stopping remote apps", "err", err)
-			} else {
-				svrCtx.Logger.Info("Successfully stopped remote apps")
-			}
+		if err := cleanupFn(); err != nil {
+			svrCtx.Logger.Error("Error stopping remote apps", "err", err)
+		} else {
+			svrCtx.Logger.Info("Successfully stopped remote apps")
+		}
 
-			// Re-send the signal to allow the normal process termination
-			signal.Reset(os.Interrupt, syscall.SIGTERM)
-			syscall.Kill(os.Getpid(), sig.(syscall.Signal))
-		}()
-	}
+		// Re-send the signal to allow the normal process termination
+		signal.Reset(os.Interrupt, syscall.SIGTERM)
+		syscall.Kill(os.Getpid(), sig.(syscall.Signal))
+	}()
 }
 
 func getAndValidateConfig(svrCtx *server.Context) (serverconfig.Config, error) {

--- a/start.go
+++ b/start.go
@@ -89,6 +89,7 @@ func start(versions abci.Versions, svrCtx *server.Context, clientCtx client.Cont
 		if err != nil {
 			return err
 		}
+
 		defer appCleanupFn()
 	}
 
@@ -99,7 +100,7 @@ func start(versions abci.Versions, svrCtx *server.Context, clientCtx client.Cont
 
 	emitServerInfoMetrics()
 
-	return startInProcess(versions, height, svrCtx, svrCfg, clientCtx, app, metrics)
+	return startInProcess(versions, height, svrCtx, svrCfg, clientCtx, app, metrics, usesLatestApp)
 }
 
 func getCurrentHeight(rootDir string, v *viper.Viper) (int64, error) {
@@ -119,6 +120,7 @@ func startInProcess(
 	clientCtx client.Context,
 	app types.Application,
 	metrics *telemetry.Metrics,
+	isLatestApp bool,
 ) error {
 	cmtCfg := svrCtx.Config
 	gRPCOnly := svrCtx.Viper.GetBool(flagGRPCOnly)
@@ -135,6 +137,10 @@ func startInProcess(
 			return err
 		}
 		defer cleanupFn()
+
+		if !isLatestApp { // latestApp isn't used, use servers from remote app
+			return g.Wait()
+		}
 
 		// Add the tx service to the gRPC router. We only need to register this
 		// service if API or gRPC is enabled, and avoid doing so in the general


### PR DESCRIPTION
support abci v1 and v2 via two remote clients.
todo in follow-up, fill in all missing fields. this may require extra field in v0.38 for backward compatibility.