### PR TITLE
feat: extend pre-handler to support multiple commands

### DIFF
--- a/abci/multiplexer.go
+++ b/abci/multiplexer.go
@@ -155,8 +155,8 @@ func (m *Multiplexer) getAppForHeight(height int64) (servertypes.ABCI, error) {
 		}
 
 		if currentVersion.Appd.Pid() == appd.AppdStopped {
-			if currentVersion.PreHandler != "" {
-				preCmd := currentVersion.Appd.CreateExecCommand(currentVersion.PreHandler)
+			for _, preHandler := range currentVersion.PreHandlers {
+				preCmd := currentVersion.Appd.CreateExecCommand(preHandler)
 				if err := preCmd.Run(); err != nil {
 					m.logger.Info("Warning: PreHandler failed", "err", err)
 					// Continue anyway as the pre-handler might be optional

--- a/abci/versions.go
+++ b/abci/versions.go
@@ -17,7 +17,7 @@ type Version struct {
 	ABCIVersion ABCIClientVersion
 	Appd        *appd.Appd
 	UntilHeight int64
-	PreHandler  string   // Command to run before starting the app
+	PreHandlers []string // Commands to run before starting the app
 	StartArgs   []string // Extra arguments to pass to the app
 }
 


### PR DESCRIPTION
prior to the v4 upgrade, we'll need to run `config migrate v0.47` and `config migrate v0.50`.
this extends support for that.