### PR TITLE
refactor: increase grpc msg size

### DIFF
--- a/abci/multiplexer.go
+++ b/abci/multiplexer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"sync"
@@ -108,9 +109,10 @@ func NewMultiplexer(
 	// remove tcp:// prefix if present
 	tmAddress = strings.TrimPrefix(tmAddress, "tcp://")
 
-	conn, err := grpc.Dial( //nolint:staticcheck: we want to check the connection.
+	conn, err := grpc.NewClient(
 		tmAddress,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(math.MaxInt), grpc.MaxCallRecvMsgSize(math.MaxInt)),
 	)
 	if err != nil {
 		return nil, noOpCleanUp, fmt.Errorf("failed to prepare app connection: %w", err)

--- a/abci/multiplexer.go
+++ b/abci/multiplexer.go
@@ -112,7 +112,10 @@ func NewMultiplexer(
 	conn, err := grpc.NewClient(
 		tmAddress,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(math.MaxInt), grpc.MaxCallRecvMsgSize(math.MaxInt)),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallSendMsgSize(math.MaxInt),
+			grpc.MaxCallRecvMsgSize(math.MaxInt),
+		),
 	)
 	if err != nil {
 		return nil, noOpCleanUp, fmt.Errorf("failed to prepare app connection: %w", err)

--- a/abci/remote_v1.go
+++ b/abci/remote_v1.go
@@ -269,16 +269,21 @@ func (a *RemoteABCIClientV1) LoadSnapshotChunk(req *abciv2.RequestLoadSnapshotCh
 
 // OfferSnapshot implements abciv2.ABCI
 func (a *RemoteABCIClientV1) OfferSnapshot(req *abciv2.RequestOfferSnapshot) (*abciv2.ResponseOfferSnapshot, error) {
+	snapshot := &abciv1.Snapshot{}
+	if req.GetSnapshot() != nil {
+		snapshot = &abciv1.Snapshot{
+			Height:   req.Snapshot.Height,
+			Format:   req.Snapshot.Format,
+			Chunks:   req.Snapshot.Chunks,
+			Hash:     req.Snapshot.Hash,
+			Metadata: req.Snapshot.Metadata,
+		}
+	}
+
 	resp, err := a.ABCIApplicationClient.OfferSnapshot(
 		context.Background(),
 		&abciv1.RequestOfferSnapshot{
-			Snapshot: &abciv1.Snapshot{
-				Height:   req.Snapshot.Height,
-				Format:   req.Snapshot.Format,
-				Chunks:   req.Snapshot.Chunks,
-				Hash:     req.Snapshot.Hash,
-				Metadata: req.Snapshot.Metadata,
-			},
+			Snapshot:   snapshot,
 			AppHash:    req.AppHash,
 			AppVersion: req.AppVersion,
 		},


### PR DESCRIPTION
We weren't able to sync with mainnet prior to this.
This shouldn't be an issue, as this connection is for the multiplexer