### PR TITLE
refactor: removing hard coded enable of GRPC, allow svrCfg to specify

### DIFF
--- a/abci/multiplexer.go
+++ b/abci/multiplexer.go
@@ -446,7 +446,6 @@ func (m *Multiplexer) getApp() (servertypes.ABCI, error) {
 
 			// NOTE: we don't need to create a comet node as that will have been created when Start was called.
 
-			m.svrCfg.GRPC.Enable = true // TODO: cleaner way than just setting field.
 			if err := m.enableGRPCAndAPIServers(app); err != nil {
 				return nil, fmt.Errorf("failed to enable gRPC and API servers: %w", err)
 			}


### PR DESCRIPTION
We don't need to force enable this, this should be configured via app.toml / cli flags when running natively.